### PR TITLE
Remove o per_page=1, para retornar todos os cartões, e utilizar o ultimo

### DIFF
--- a/src/routes/RoutesApi.php
+++ b/src/routes/RoutesApi.php
@@ -451,7 +451,7 @@ class VindiRoutes
       return false;
 
     $query    = urlencode("customer_id={$user_vindi_id} status=active type=PaymentProfile::CreditCard");
-    $response = $this->api->request('payment_profiles?per_page=1&query='.$query, 'GET');
+    $response = $this->api->request('payment_profiles?&query='.$query, 'GET');
 
     if (end($response['payment_profiles']) !== null)
       return end($response['payment_profiles']);


### PR DESCRIPTION
remove o per_page=1, para que todos os cartões sejam retornados, dessa forma, o trecho abaixo "end($response['payment_profiles']);" retornará o ultimo cartão utilizado pelo cliente, em vez do primeiro, que era exibido erroneamente. 